### PR TITLE
Add atlas.cern.ch and sft.cern.ch

### DIFF
--- a/cvmfs-daemonset/cvmfs-nodeplugin.yaml
+++ b/cvmfs-daemonset/cvmfs-nodeplugin.yaml
@@ -30,7 +30,7 @@ spec:
               command: ["/usr/local/sbin/unmount-and-terminate.sh"]
         env:
         - name: MOUNT_REPOS
-          value: "config-osg.opensciencegrid.org,icecube.opensciencegrid.org,oasis.opensciencegrid.org,connect.opensciencegrid.org,singularity.opensciencegrid.org,xenon.opensciencegrid.org,fermilab.opensciencegrid.org,nova.opensciencegrid.org,cms.cern.ch,cms-ib.cern.ch"
+          value: "config-osg.opensciencegrid.org,icecube.opensciencegrid.org,oasis.opensciencegrid.org,connect.opensciencegrid.org,singularity.opensciencegrid.org,xenon.opensciencegrid.org,fermilab.opensciencegrid.org,nova.opensciencegrid.org,cms.cern.ch,cms-ib.cern.ch,atlas.cern.ch,sft.cern.ch"
         - name: SQUID_URI
           value: "http://frontier-squid:3128"
         resources:

--- a/cvmfs-pvcs/cvmfs-pv-cern-atlas.yaml
+++ b/cvmfs-pvcs/cvmfs-pv-cern-atlas.yaml
@@ -1,0 +1,45 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cvmfs-cern-atlas
+# Local storage does not need a provisioner
+provisioner: kubernetes.io/no-provisioner
+# Give it out as-is
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cvmfs-cern-atlas
+spec:
+  capacity:
+    storage: 2Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: cvmfs-cern-atlas
+  local:
+    path: /var/lib/cvmfs-k8s/atlas.cern.ch
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: NotIn
+          values:
+          -  fake
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cvmfs-cern-atlas
+  namespace: cvmfs
+spec:
+  accessModes:
+  - ReadOnlyMany
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: cvmfs-cern-atlas

--- a/cvmfs-pvcs/cvmfs-pv-cern-sft.yaml
+++ b/cvmfs-pvcs/cvmfs-pv-cern-sft.yaml
@@ -1,0 +1,45 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cvmfs-cern-sft
+# Local storage does not need a provisioner
+provisioner: kubernetes.io/no-provisioner
+# Give it out as-is
+reclaimPolicy: Retain
+volumeBindingMode: Immediate
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: cvmfs-cern-sft
+spec:
+  capacity:
+    storage: 2Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadOnlyMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: cvmfs-cern-sft
+  local:
+    path: /var/lib/cvmfs-k8s/sft.cern.ch
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: NotIn
+          values:
+          -  fake
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cvmfs-cern-sft
+  namespace: cvmfs
+spec:
+  accessModes:
+  - ReadOnlyMany
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: cvmfs-cern-sft


### PR DESCRIPTION
Horst Severini is asking that we make `/cvmfs/{atlas,sft}.cern.ch` available within the OSG JupyterHub instance, which is currently running on Tiger.

If I understand how the CVMFS mounts are currently configured, this PR should be sufficient to get the PersistentVolumes and PersistentVolumeClaims into the OSG namespaces on the cluster. I will need to separately update the DaemonSet in the cluster config.